### PR TITLE
HTTPS and GitHub

### DIFF
--- a/lib/seinfeld/feed.rb
+++ b/lib/seinfeld/feed.rb
@@ -8,7 +8,7 @@ class Seinfeld
       attr_accessor :user_agent
       attr_writer   :connection
     end
-    self.user_agent = 'Calendar About Nothing: http://github.com/technoweenie/seinfeld'
+    self.user_agent = 'Calendar About Nothing: https://github.com/technoweenie/seinfeld'
 
     # A Array of Hashes of the parsed event JSON.
     attr_reader :items
@@ -37,7 +37,7 @@ class Seinfeld
     # Returns Seinfeld::Feed instance.
     def self.fetch(login)
       user = login.is_a?(User) ? login : User.new(:login => login.to_s)
-      url  = "http://github.com/#{user.login}.json"
+      url  = "https://github.com/#{user.login}.json"
       resp = connection.get(url, 'If-None-Match' => user.etag)
       new(login, resp, url)
     rescue Yajl::ParseError, Faraday::Error::ClientError

--- a/lib/seinfeld/templates/auth.mustache
+++ b/lib/seinfeld/templates/auth.mustache
@@ -7,7 +7,7 @@
     <form action="/create" method="post">
       <p>
         You are just <em>one step away</em> from joining an amazing community of
-        <a href="http://github.com">GitHub</a> open source developers.  Click this,
+        <a href="https://github.com">GitHub</a> open source developers.  Click this,
         and CAN will start tracking your daily open source progress.
       </p>
       <p><input type="submit" value="Awesome" /></p>

--- a/lib/seinfeld/templates/layout.mustache
+++ b/lib/seinfeld/templates/layout.mustache
@@ -34,7 +34,7 @@
         <a href="http://calendaraboutnothing.com">Calendar About Nothing</a>
         by <a href="http://techno-weenie.net">rick</a> and 
         <a href="http://warpspire.com/">kyle</a> / 
-        <a href="http://github.com">GitHub</a>
+        <a href="https://github.com">GitHub</a>
       </div>
     </div>
   </body>

--- a/public/javascripts/widget/seinfeld-badge.js
+++ b/public/javascripts/widget/seinfeld-badge.js
@@ -20,7 +20,7 @@
                 }).append('<img src="http://calendaraboutnothing.com/images/x_1.png" height="80%" width="50%">');
                 $progressed.append($x);
              });
-            $seinfeld.append($streaks).append('<p class="pimpage"><a href="http://github.com/lachlanhardy/seinfeld-badge">Want your own badge?</a></p>');
+            $seinfeld.append($streaks).append('<p class="pimpage"><a href="https://github.com/lachlanhardy/seinfeld-badge">Want your own badge?</a></p>');
         });
     });
 })();

--- a/public/styles/widget/seinfeld-badge.css
+++ b/public/styles/widget/seinfeld-badge.css
@@ -1,6 +1,6 @@
 /****
 Seinfeld Badge
-http://github.com/lachlanhardy/seinfeld-badge
+https://github.com/lachlanhardy/seinfeld-badge
 20100516
 
 ****/

--- a/views/group.haml
+++ b/views/group.haml
@@ -13,11 +13,11 @@
     .subtitle
       for
       - for user in @users
-        %a{:href => "http://github.com/#{user}"}
+        %a{:href => "https://github.com/#{user}"}
           = user
     #calendar
       = group_seinfeld
     #main
       #content.footnote 
         %a{:href => "http://calendaraboutnothing.com"} Calendar About Nothing
-        by <a href="http://techno-weenie.net">rick</a> and <a href="http://warpspire.com/">kyle</a> / <a href="http://github.com">GitHub</a>
+        by <a href="http://techno-weenie.net">rick</a> and <a href="http://warpspire.com/">kyle</a> / <a href="https://github.com">GitHub</a>

--- a/views/index.haml
+++ b/views/index.haml
@@ -13,7 +13,7 @@
           The Calendar About Nothing generates a 
           "<a href="http://lifehacker.com/software/motivation/jerry-seinfelds-productivity-secret-281626.php">Seinfeld Calendar</a>"
           from your public
-          "<a href="http://github.com">GitHub</a>" feed.
+          "<a href="https://github.com">GitHub</a>" feed.
         %p
           %strong Commit
           to an open source project: get an 
@@ -35,7 +35,7 @@
         %h2 How can I help?
         %p 
           We have the ruby source code 
-          %a{:href => "http://github.com/technoweenie/seinfeld/tree/master"} on the githubs.
+          %a{:href => "https://github.com/technoweenie/seinfeld/tree/master"} on the githubs.
           Join in, it's a fun little 
           %a{:href => "http://www.sinatrarb.com"} Sinatra
           app!
@@ -56,4 +56,4 @@
     #main
       #content.footnote 
         %a{:href => "http://calendaraboutnothing.com"} Calendar About Nothing
-        by <a href="http://techno-weenie.net">rick</a> and <a href="http://warpspire.com/">kyle</a> / <a href="http://github.com">GitHub</a>
+        by <a href="http://techno-weenie.net">rick</a> and <a href="http://warpspire.com/">kyle</a> / <a href="https://github.com">GitHub</a>

--- a/views/show.haml
+++ b/views/show.haml
@@ -8,7 +8,7 @@
     %script{:type => 'text/javascript', :src => '/javascripts/application.js'}
   %body
     .title 
-      %a{:rel => "me", :href => "http://github.com/#{@user.login}"}
+      %a{:rel => "me", :href => "https://github.com/#{@user.login}"}
         == #{@user.login}'s
       Calendar
     .subtitle Tracking Open Source Contributions
@@ -31,7 +31,7 @@
               %span.desc days
       #content.footnote 
         %a{:href => "http://calendaraboutnothing.com"} Calendar About Nothing
-        by <a href="http://techno-weenie.net">rick</a> and <a href="http://warpspire.com/">kyle</a> / <a href="http://github.com">GitHub</a>
+        by <a href="http://techno-weenie.net">rick</a> and <a href="http://warpspire.com/">kyle</a> / <a href="https://github.com">GitHub</a>
       #content.footnote 
         Put the 
         %a{:href=> "/~#{@user.login}/widget"} JavaScript widget

--- a/views/widget.haml
+++ b/views/widget.haml
@@ -6,15 +6,15 @@
     %link{:rel => 'stylesheet', :type => 'text/css', :href => '/styles/main.css'}
   %body
     .title 
-      %a{:rel => "me", :href => "http://github.com/#{@user.login}"}
+      %a{:rel => "me", :href => "https://github.com/#{@user.login}"}
         == #{@user.login}'s
       CAN Widget
     %form#widget
       %p
         This JavaScript widget was written by
-        %a{:href => "http://github.com/lachlanhardy"} lachlanhardy
+        %a{:href => "https://github.com/lachlanhardy"} lachlanhardy
         and uses jQuery.  Please direct any requests or patches to the
-        %a{:href => "http://github.com/lachlanhardy/seinfeld-badge"} seinfeld-badge
+        %a{:href => "https://github.com/lachlanhardy/seinfeld-badge"} seinfeld-badge
         repo so they can be pushed upstream to the CAN.
       %p
         %textarea
@@ -23,7 +23,7 @@
 
             <div class="seinfeld-badge user-#{@user.login}">
               <h2>I like open software</h2>
-              <p><a href="http://calendaraboutnothing.com/~#{@user.login}" rel="me">Calendar About Nothing</a> tracks my public contributions on <A href="http://github.com/#{@user.login}">GitHub</a>.</p>
+              <p><a href="http://calendaraboutnothing.com/~#{@user.login}" rel="me">Calendar About Nothing</a> tracks my public contributions on <A href="https://github.com/#{@user.login}">GitHub</a>.</p>
             </div> <!-- .seinfeld-badge .user-#{@user.login} -->
             
             <!-- Using Google's CDN for JS -->
@@ -53,4 +53,4 @@
               %span.desc days
       #content.footnote 
         %a{:href => "http://calendaraboutnothing.com"} Calendar About Nothing
-        by <a href="http://techno-weenie.net">rick</a> and <a href="http://warpspire.com/">kyle</a> / <a href="http://github.com">GitHub</a>
+        by <a href="http://techno-weenie.net">rick</a> and <a href="http://warpspire.com/">kyle</a> / <a href="https://github.com">GitHub</a>


### PR DESCRIPTION
Now that GitHub has gone solely HTTPS, the CAN broke!  This is just a quick patch to get it back up and running for everyone.
