### PR TITLE
Fixes handling of Github Users API response

### DIFF
--- a/lib/seinfeld/app.rb
+++ b/lib/seinfeld/app.rb
@@ -114,7 +114,7 @@ class Seinfeld
       begin
         api  = oauth.get_access_token(params[:code], :redirect_uri => oauth_redirect_url)
         data = Yajl::Parser.parse(api.get('https://api.github.com/user'))
-        session[:user] = data['user']
+        session[:user] = github_attributes(data)
         redirect "/edit"
       rescue Yajl::ParseError
         %(<p>#{$!}</p>)
@@ -229,6 +229,11 @@ class Seinfeld
       uri.path  = '/auth/callback'
       uri.query = nil
       uri.to_s
+    end
+
+    def github_attributes(api_response)
+      keys = %w(login location)
+      api_response.select{ |k, v| keys.include?(k) }
     end
   end
 end

--- a/lib/seinfeld/user.rb
+++ b/lib/seinfeld/user.rb
@@ -192,8 +192,7 @@ class Seinfeld
     def update_location!
       data = Yajl::Parser.parse(http_conn.get("https://api.github.com/users/#{login}").body)
       return if data.nil?
-      return if data["user"].nil?
-      self.location = data["user"]["location"]
+      self.location = data["location"]
       save!
     end
     

--- a/test/user_test.rb
+++ b/test/user_test.rb
@@ -175,7 +175,7 @@ class UserTest < ActiveSupport::TestCase
     Faraday::Connection.new do |builder|
       builder.adapter :test do |stub|
         stub.get('/users/bob') do
-          [200, {}, '{"user":{"name":"Bob"}}']
+          [200, {}, '{"name":"Bob"}']
         end
       end
     end
@@ -189,7 +189,7 @@ class UserTest < ActiveSupport::TestCase
     Faraday::Connection.new do |builder|
       builder.adapter :test do |stub|
         stub.get('/users/bob') do
-          [200, {}, '{"user":{"name":"Bob","location":"Boulder, CO"}}']
+          [200, {}, '{"name":"Bob","location":"Boulder, CO"}']
         end
       end
     end


### PR DESCRIPTION
I noticed that currently OAuth is broken in the current calendar site. I took a look and it seems that the handling of the Github API response changed, so I took a stab at fixing it. Hopefully this doesn't screw anything up.

FYI: The `github_attributes` method I wrote in app.rb to only get the attributes that are currently used was because I couldn't save the entire API response in the session due the 4K cookie limitation in Rack::Session (apparently my bio is too long).
